### PR TITLE
Add Group Name and Separate update and upload endpoints

### DIFF
--- a/src/controllers/group.js
+++ b/src/controllers/group.js
@@ -11,11 +11,11 @@ const { ObjectId } = mongoose.Types;
 const Group = {
   register: async (req, res, next) => {
     const {
-      users, creator, invitedUsers, publicGroup,
+      users, creator, invitedUsers, publicGroup, name,
     } = req.body;
     const newGroup = new GroupModel(
       {
-        users, creator, invitedUsers, publicGroup,
+        users, creator, invitedUsers, publicGroup, name,
       },
     );
 
@@ -165,6 +165,29 @@ const Group = {
         404,
         `/groups/${id}/`,
       ));
+    }
+
+    return res.status(204).send();
+  },
+
+  update: async (req, res, next) => {
+    const { id } = req.params;
+
+    try {
+      await GroupModel.findByIdAndUpdate(
+        id,
+        req.body,
+      );
+    } catch (err) {
+      if (err.code === 11000) {
+        return next(new APIError(
+          'Name is taken',
+          'The name you provided is already taken.',
+          409,
+        ));
+      }
+
+      return next(new APIError());
     }
 
     return res.status(204).send();

--- a/src/models/group.js
+++ b/src/models/group.js
@@ -11,7 +11,7 @@ const groupSchema = new mongoose.Schema({
   invitedUsers: [{ type: mongoose.Schema.Types.ObjectId, ref: User }],
   images: [{ type: mongoose.Schema.Types.ObjectId, ref: Image }],
   publicGroup: { type: Boolean, default: false },
-  name: { type: String, required: true, unique: true },
+  name: { type: String, required: true },
 });
 
 const populateFields = 'users creator invitedUsers';

--- a/src/models/group.js
+++ b/src/models/group.js
@@ -11,6 +11,7 @@ const groupSchema = new mongoose.Schema({
   invitedUsers: [{ type: mongoose.Schema.Types.ObjectId, ref: User }],
   images: [{ type: mongoose.Schema.Types.ObjectId, ref: Image }],
   publicGroup: { type: Boolean, default: false },
+  name: { type: String, required: true, unique: true },
 });
 
 const populateFields = 'users creator invitedUsers';

--- a/src/routes/group.js
+++ b/src/routes/group.js
@@ -168,7 +168,7 @@ groups.post('/join/:inviteCode', Group.join);
 /**
  * @swagger
  * path:
- * /groups/{id}:
+ * /groups/{id}/uploadImage:
  *    put:
  *      description: Uploads an image to a group
  *      summary: Upload an image to a group
@@ -203,7 +203,54 @@ groups.post('/join/:inviteCode', Group.join);
  *          description: Invalid Group ID
  *        415:
  *          description: File not provided
+ *        default:
+ *          description: Unexpected Error
+ *          content:
+ *            application/json:
+ *              schema:
+ *                $ref: '#/components/schemas/APIError'
  */
-groups.put('/:id', upload.single('groupPicture'), Group.upload);
+groups.put('/:id/uploadImage', upload.single('groupPicture'), Group.upload);
+
+/**
+ * @swagger
+ * path:
+ * /groups/{id}:
+ *    put:
+ *      description: Updates a group
+ *      summary: Updates the content of a group
+ *      tags:
+ *      - Group
+ *
+ *      parameters:
+ *        - in: path
+ *          name: id
+ *          required: true
+ *          schema:
+ *            type: string
+ *          description: The ID of the group to update
+ *
+ *      requestBody:
+ *        required: true
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: '#/components/schemas/GroupUpdate'
+ *
+ *      produces:
+ *        - application/json
+ *      responses:
+ *        204:
+ *          description: OK
+ *        409:
+ *          description: Name taken
+ *        default:
+ *          description: Unexpected Error
+ *          content:
+ *            application/json:
+ *              schema:
+ *                $ref: '#/components/schemas/APIError'
+ */
+groups.put('/:id', Group.update);
 
 export default groups;

--- a/src/schemas.yml
+++ b/src/schemas.yml
@@ -107,6 +107,12 @@ GroupRequest:
     creator:
       type: string
       required: true
+GroupUpdate:
+  type: object
+  properties:
+    name:
+      type: string
+      required: true
 GroupUpload:
   type: object
   properties:

--- a/src/schemas.yml
+++ b/src/schemas.yml
@@ -97,6 +97,9 @@ GroupRequest:
     creator:
       type: string
       required: true
+    name:
+      type: string
+      required: true
 GroupUpdate:
   type: object
   properties:


### PR DESCRIPTION
Creating a group now requires a name, `PUT groups/` is now only used for updating a group and uploading an image to a group is now done via `PUT groups/{id}/uploadImage`.