### PR TITLE
Minify User Responses

### DIFF
--- a/src/controllers/group.js
+++ b/src/controllers/group.js
@@ -27,8 +27,13 @@ const Group = {
       newGroup.inviteCode = uuidv4();
       const group = await newGroup.save();
       req.params.id = group._id;
+
       // req.body.emails is used here!
       await Group.inviteUsers(true)(req, res, next);
+      // Add the creator to the group.
+      await GroupModel.findByIdAndUpdate(group, { $push: { users: creator } }).exec();
+      // Push the ID on the user model.
+      await UserModel.findByIdAndUpdate(creator, { $push: { groups: group._id } }).exec();
       return res.status(200).send(group.toJSON());
     } catch (err) {
       return next(new APIError('Group Creation Failed',

--- a/src/controllers/group.js
+++ b/src/controllers/group.js
@@ -45,8 +45,12 @@ const Group = {
 
   join: async (req, res, next) => {
     const { inviteCode } = req.params;
+    const userID = req.body.user;
     let group = (await GroupModel
       .findOne({ inviteCode })
+      .exec());
+    const user = (await UserModel
+      .findById(userID)
       .exec());
 
     // Check if group is found.
@@ -60,18 +64,18 @@ const Group = {
       );
     }
 
-    // Check if user is authorized to join.
-    if (!ObjectId.isValid(req.body.user)) {
-      return next(new APIError(
-        'Bad User ObjectId',
-        'The given ObjectId for the joining user is invalid',
-        404,
-        `/groups/join/${inviteCode}`,
-      ));
+    // Check if user was found.
+    if (user === null) {
+      return next(
+        new APIError(
+          'User not found',
+          'User does not exist',
+          404,
+        ),
+      );
     }
-    const user = ObjectId(req.body.user);
 
-    if (group.users.some((x) => x.equals(user))) {
+    if (user.groups.some((x) => x.equals(group._id))) {
       return next(new APIError(
         'Failed to join group',
         'User is already in this group',
@@ -79,18 +83,12 @@ const Group = {
       ));
     }
 
-    if (group.creator && group.creator._id.equals(user._id)) {
-      return res.status(204).send(group.toJSON());
-    }
-
-    const authorizedUser = (group.invitedUsers).some(x => x.equals(user));
+    const authorizedUser = (group.invitedUsers).some(x => x.equals(user._id));
 
     if (authorizedUser || group.publicGroup) {
       await UserModel.findByIdAndUpdate(user, { $push: { groups: group._id } }).exec();
       // remove user from group's invited users array
-      await group.updateOne({ $pull: { invitedUsers: user } });
-      // put user into group's user array
-      await group.updateOne({ $push: { users: user } });
+      await group.updateOne({ $pull: { invitedUsers: user._id } });
       // get updated group information
       group = (await GroupModel
         .findOne({ inviteCode })

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -166,6 +166,18 @@ const User = {
     return res.status(200).send(retVal);
   },
 
+  fetchGroups: async (req, res, next) => {
+    const { id } = req.params;
+    let user;
+    try {
+      user = await UserModel.findById(id).exec();
+    } catch (err) {
+      return next(new APIError());
+    }
+
+    return res.status(200).send(user.toJSON().groups);
+  },
+
   update: async (req, res, next) => {
     const { id } = req.params;
     let result;

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -170,7 +170,7 @@ const User = {
     const { id } = req.params;
     let user;
     try {
-      user = await UserModel.findById(id).exec();
+      user = await (await UserModel.findById(id).populate('groups')).execPopulate();
     } catch (err) {
       return next(new APIError());
     }

--- a/src/models/group.js
+++ b/src/models/group.js
@@ -7,7 +7,6 @@ const modelName = 'Group';
 
 const groupSchema = new mongoose.Schema({
   inviteCode: { type: String, required: true, unique: true },
-  users: { type: [{ type: mongoose.Schema.Types.ObjectId, ref: User }], default: [] },
   creator: { type: mongoose.Schema.Types.ObjectId, ref: User, required: true },
   invitedUsers: { type: [{ type: mongoose.Schema.Types.ObjectId, ref: User }], default: [] },
   publicGroup: { type: Boolean, default: false },
@@ -28,6 +27,9 @@ const deepDelete = async function deepDelete() {
 const populateFields = 'users creator invitedUsers';
 
 const autoPopulate = async function populator(doc) {
+  if (!doc) {
+    return;
+  }
   await doc.populate(populateFields).execPopulate();
 };
 

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -18,16 +18,16 @@ const userSchema = new mongoose.Schema({
   groups: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Group' }],
 });
 
-const populateFields = 'groups';
+// const populateFields = 'groups';
 
-const autoPopulate = async function populator(doc) {
-  if (!doc) {
-    return;
-  }
-  await doc.populate(populateFields).execPopulate();
-};
+// const autoPopulate = async function populator(doc) {
+//   if (!doc) {
+//     return;
+//   }
+//   await doc.populate(populateFields).execPopulate();
+// };
 
-userSchema.post('findOne', autoPopulate);
+// userSchema.post('findOne', autoPopulate);
 
 const User = mongoose.model(modelName, userSchema);
 

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -21,6 +21,9 @@ const userSchema = new mongoose.Schema({
 const populateFields = 'groups';
 
 const autoPopulate = async function populator(doc) {
+  if (!doc) {
+    return;
+  }
   await doc.populate(populateFields).execPopulate();
 };
 

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -366,4 +366,41 @@ router.post('/passwordRecovery', User.emailPasswordRecovery);
  *                $ref: '#/components/schemas/APIError'
  */
 router.post('/resendVerificationEmail', User.resendVerificationEmail);
+
+/**
+ * @swagger
+ * path:
+ * /users/{id}/groups:
+ *   get:
+ *     description: Gets the groups associated with the user.
+ *     summary: Get the User's groups
+ *     tags:
+ *     - User
+ *
+ *     produces:
+ *       - application/json
+ *     responses:
+ *       200:
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 groups:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Group'
+ *       404:
+ *         description: Could not find user
+ *       503:
+ *         description: Failure to send email
+ *       default:
+ *          description: Unexpected Error
+ *          content:
+ *            application/json:
+ *              schema:
+ *                $ref: '#/components/schemas/APIError'
+ */
+router.get('/:id/groups', User.fetchGroups);
 export default router;

--- a/src/schemas.yml
+++ b/src/schemas.yml
@@ -80,20 +80,12 @@ Group:
       example: 7834dfae4eb89145bc13b559
     inviteCode:
       type: string
-    users:
-      type: array
-      items:
-        $ref: '#/components/schemas/UserResponse'
     creator:
       $ref: '#/components/schemas/UserResponse'
     invitedUsers:
       type: array
       items:
         $ref: '#/components/schemas/UserResponse'
-    images:
-      type: array
-      items:
-        $ref: '#/components/schemas/Image'
     thumbnail:
       $ref: '#/components/schemas/Image'
     publicGroup:

--- a/src/test/API.test.js
+++ b/src/test/API.test.js
@@ -98,12 +98,12 @@ describe('Group API Methods', () => {
     expect(res.body).toMatchObject(groupPayload);
   });
 
-  test('Join new group', async () => {
+  test('Show Group Membership', async () => {
     const res = await request(app)
-      .post(`/groups/${groupPayload.inviteCode}/join`)
-      .send({ user: userPayload.id })
-      .expect(204);
+      .get(`/users/${userPayload.id}/groups`)
+      .expect('Content-Type', /json/)
+      .expect(200);
 
-    groupPayload.invitedUsers = res.body.invitedUsers;
+    expect(res.body[0].id === groupPayload.id);
   });
 });


### PR DESCRIPTION
This PR reduces the JSON response size of a couple of requests, and instead opts for moving them into their own endpoints.

`GET /users/:id` now returns something like this:
```json
{
    "verified": true,
    "groups": [
        "607b4c80e86e2fade14bb178"
    ],
    "firstName": "Suneet",
    "lastName": "Tipirneni",
    "email": "imawesome@gmail.com",
    "username": "suneettipirneni",
    "verificationCode": "f3047541-30f2-4473-a9b8-30ef64dff0bc",
    "id": "6078a2e69aafec184762aa01",
    "imgURL": "https://image-sharing-project.s3.us-east-1.amazonaws.com/users/6078a2e69aafec184762aa01/profile.jpeg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAWB3YRRPZ5RR3DN72%2F20210418%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20210418T055030Z&X-Amz-Expires=900&X-Amz-Signature=7f11fab88da1f7d1f7f5701bce7deab28d13f75fb0ad1582990ad750b3b2652a&X-Amz-SignedHeaders=host&x-amz-user-agent=aws-sdk-js%2F3.12.0%20os%2Fdarwin%2F20.3.0%20lang%2Fjs%20md%2Fnodejs%2F14.16.0%20api%2Fs3%2F3.12.0&x-id=GetObject"
}
```

To get the details of groups associated with a user a call to `GET user/:id/groups` is needed:

```json
[
    {
        "invitedUsers": [],
        "publicGroup": true,
        "name": "My Awesome Epic Group",
        "thumbnail": null,
        "users": [],
        "creator": {
            "verified": true,
            "groups": [
                "607b4c80e86e2fade14bb178"
            ],
            "firstName": "Suneet",
            "lastName": "Tipirneni",
            "email": "imawesome@gmail.com",
            "username": "suneettipirneni",
            "verificationCode": "f3047541-30f2-4473-a9b8-30ef64dff0bc",
            "id": "6078a2e69aafec184762aa01"
        },
        "inviteCode": "d959e4b9-faf5-4f31-baf7-cf6a1de7641a",
        "id": "607b4c80e86e2fade14bb178"
    }
]
```